### PR TITLE
Support gitops

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,5 @@ rand = "0.8.4"
 libsm = "0.4.0"
 anyhow = "1"
 fs_extra = "1.2"
+k8s-openapi = { version = "0.14.0", features = ["v1_23"] }
+serde_yaml = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,26 +1,24 @@
 [package]
 name = "cloud-config"
-version = "6.3.3"
-authors = ["Yieazy <yuitta@163.com>"]
+version = "6.4.0"
+authors = ["Rivtower Technologies <contact@rivtower.com>"]
 license = "Apache-2.0"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap = { version = "3.1.6", features = ["derive"] }
+clap = { version = "3.1.8", features = ["derive"] }
 log = "0.4"
 serde = { version = "1", features = ["derive"] }
 kms_sm = { git = "https://github.com/cita-cloud/kms_sm", package = "kms" }
 kms_eth = { git = "https://github.com/cita-cloud/kms_eth", package = "kms" }
 toml = "0.5"
 hex = "0.4"
-regex = "1"
-rcgen = { version = "0.8", features = ["pem", "x509-parser"] }
-x509-parser = "0.12"
-rand = "0.8.4"
-libsm = "0.4.0"
+rcgen = { version = "0.9", features = ["pem", "x509-parser"] }
+x509-parser = "0.13"
+rand = "0.8"
+libsm = "0.4"
 anyhow = "1"
-fs_extra = "1.2"
-k8s-openapi = { version = "0.14.0", features = ["v1_23"] }
+k8s-openapi = { version = "0.14", features = ["v1_23"] }
 serde_yaml = "0.8"

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /build
 RUN /bin/sh -c set -eux;\
     rustup component add rustfmt;\
     apt-get update;\
-    apt-get install -y --no-install-recommends libsqlite3-dev git;\
+    apt-get install -y --no-install-recommends libsqlite3-dev;\
     rm -rf /var/lib/apt/lists/*;
 COPY . /build/
 RUN cargo build --release

--- a/src/append_node.rs
+++ b/src/append_node.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::config::chain_config::ConfigStage;
 use crate::config::chain_config::NodeNetworkAddressBuilder;
 use crate::constant::CHAIN_CONFIG_FILE;
 use crate::error::Error;
@@ -40,6 +41,10 @@ pub fn execute_append_node(opts: AppendNodeOpts) -> Result<(), Error> {
         &opts.config_dir, &opts.chain_name, CHAIN_CONFIG_FILE
     );
     let mut chain_config = read_chain_config(&file_name).unwrap();
+
+    if chain_config.stage == ConfigStage::Init {
+        return Err(Error::InvalidStage);
+    }
 
     let mut node_list = chain_config.node_network_address_list.clone();
 

--- a/src/append_node.rs
+++ b/src/append_node.rs
@@ -28,13 +28,13 @@ pub struct AppendNodeOpts {
     /// set config file directory, default means current directory
     #[clap(long = "config-dir", default_value = ".")]
     pub(crate) config_dir: String,
-    /// node network address looks like localhost:40002:node2:k8s_cluster1:40000
-    /// last two slice is optional, none means not k8s env.
+    /// node network address looks like localhost:40002:node2:k8s_cluster1
+    /// last slice is optional, none means not k8s env.
     #[clap(long = "node")]
     pub(crate) node: String,
 }
 
-/// execute set node list
+/// execute append node
 pub fn execute_append_node(opts: AppendNodeOpts) -> Result<(), Error> {
     // load chain_config
     let file_name = format!(
@@ -56,19 +56,12 @@ pub fn execute_append_node(opts: AppendNodeOpts) -> Result<(), Error> {
         node_network_info[3].to_string()
     };
 
-    let svc_port = if node_network_info.len() == 3 {
-        40000
-    } else {
-        node_network_info[4].parse::<u16>().unwrap()
-    };
-
     node_list.push(
         NodeNetworkAddressBuilder::new()
             .host(node_network_info[0].to_string())
             .port(node_network_info[1].parse::<u16>().unwrap())
             .domain(node_network_info[2].to_string())
             .cluster(cluster)
-            .svc_port(svc_port)
             .build(),
     );
 

--- a/src/append_node.rs
+++ b/src/append_node.rs
@@ -16,7 +16,7 @@ use crate::config::chain_config::ConfigStage;
 use crate::config::chain_config::NodeNetworkAddressBuilder;
 use crate::constant::CHAIN_CONFIG_FILE;
 use crate::error::Error;
-use crate::util::{read_chain_config, write_toml};
+use crate::util::{rand_string, read_chain_config, write_toml};
 use clap::Parser;
 
 /// A subcommand for run
@@ -28,7 +28,8 @@ pub struct AppendNodeOpts {
     /// set config file directory, default means current directory
     #[clap(long = "config-dir", default_value = ".")]
     pub(crate) config_dir: String,
-    /// node network address looks like localhost:40002:node2
+    /// node network address looks like localhost:40002:node2:k8s_cluster1:40000
+    /// last two slice is optional, none means not k8s env.
     #[clap(long = "node")]
     pub(crate) node: String,
 }
@@ -49,11 +50,25 @@ pub fn execute_append_node(opts: AppendNodeOpts) -> Result<(), Error> {
     let mut node_list = chain_config.node_network_address_list.clone();
 
     let node_network_info: Vec<&str> = opts.node.split(':').collect();
+    let cluster = if node_network_info.len() == 3 {
+        rand_string()
+    } else {
+        node_network_info[3].to_string()
+    };
+
+    let svc_port = if node_network_info.len() == 3 {
+        40000
+    } else {
+        node_network_info[4].parse::<u16>().unwrap()
+    };
+
     node_list.push(
         NodeNetworkAddressBuilder::new()
             .host(node_network_info[0].to_string())
             .port(node_network_info[1].parse::<u16>().unwrap())
             .domain(node_network_info[2].to_string())
+            .cluster(cluster)
+            .svc_port(svc_port)
             .build(),
     );
 

--- a/src/append_validator.rs
+++ b/src/append_validator.rs
@@ -32,7 +32,7 @@ pub struct AppendValidatorOpts {
     pub(crate) validator: String,
 }
 
-/// execute set validators
+/// execute append validator
 pub fn execute_append_validator(opts: AppendValidatorOpts) -> Result<(), Error> {
     // load chain_config
     let file_name = format!(

--- a/src/config/chain_config.rs
+++ b/src/config/chain_config.rs
@@ -23,6 +23,8 @@ pub struct NodeNetworkAddress {
     pub host: String,
     pub port: u16,
     pub domain: String,
+    pub cluster: String,
+    pub svc_port: u16,
 }
 
 impl PartialEq for NodeNetworkAddress {
@@ -43,6 +45,8 @@ pub struct NodeNetworkAddressBuilder {
     pub host: String,
     pub port: u16,
     pub domain: String,
+    pub cluster: String,
+    pub svc_port: u16,
 }
 
 impl NodeNetworkAddressBuilder {
@@ -51,6 +55,8 @@ impl NodeNetworkAddressBuilder {
             host: "localhost".to_string(),
             port: 0,
             domain: "".to_string(),
+            cluster: "".to_string(),
+            svc_port: 40000,
         }
     }
 
@@ -69,11 +75,23 @@ impl NodeNetworkAddressBuilder {
         self
     }
 
+    pub fn cluster(&mut self, cluster: String) -> &mut NodeNetworkAddressBuilder {
+        self.cluster = cluster;
+        self
+    }
+
+    pub fn svc_port(&mut self, svc_port: u16) -> &mut NodeNetworkAddressBuilder {
+        self.svc_port = svc_port;
+        self
+    }
+
     pub fn build(&self) -> NodeNetworkAddress {
         NodeNetworkAddress {
             host: self.host.clone(),
             port: self.port,
             domain: self.domain.clone(),
+            cluster: self.cluster.clone(),
+            svc_port: self.svc_port,
         }
     }
 }

--- a/src/config/chain_config.rs
+++ b/src/config/chain_config.rs
@@ -80,6 +80,7 @@ impl NodeNetworkAddressBuilder {
         self
     }
 
+    #[allow(dead_code)]
     pub fn svc_port(&mut self, svc_port: u16) -> &mut NodeNetworkAddressBuilder {
         self.svc_port = svc_port;
         self

--- a/src/config/chain_config.rs
+++ b/src/config/chain_config.rs
@@ -115,12 +115,20 @@ impl MicroServiceBuilder {
     }
 }
 
+#[derive(Debug, Serialize, Clone, Deserialize, PartialEq)]
+pub enum ConfigStage {
+    Init,
+    Public,
+    Finalize,
+}
+
 #[derive(Debug, Serialize, Clone, Deserialize)]
 pub struct ChainConfig {
     pub system_config: SystemConfigFile,
     pub genesis_block: GenesisBlock,
     pub node_network_address_list: Vec<NodeNetworkAddress>,
     pub micro_service_list: Vec<MicroService>,
+    pub stage: ConfigStage,
 }
 
 impl ChainConfig {
@@ -135,6 +143,10 @@ impl ChainConfig {
     pub fn set_node_network_address_list(&mut self, node_list: Vec<NodeNetworkAddress>) {
         self.node_network_address_list = node_list;
     }
+
+    pub fn set_stage(&mut self, stage: ConfigStage) {
+        self.stage = stage;
+    }
 }
 
 pub struct ChainConfigBuilder {
@@ -142,6 +154,7 @@ pub struct ChainConfigBuilder {
     pub genesis_block: GenesisBlock,
     pub node_network_address_list: Vec<NodeNetworkAddress>,
     pub micro_service_list: Vec<MicroService>,
+    pub stage: ConfigStage,
 }
 
 impl ChainConfigBuilder {
@@ -151,6 +164,7 @@ impl ChainConfigBuilder {
             genesis_block: GenesisBlockBuilder::new().build(),
             node_network_address_list: Vec::new(),
             micro_service_list: Vec::new(),
+            stage: ConfigStage::Init,
         }
     }
     pub fn system_config(&mut self, system_config: SystemConfigFile) -> &mut ChainConfigBuilder {
@@ -186,6 +200,7 @@ impl ChainConfigBuilder {
             genesis_block: self.genesis_block.clone(),
             node_network_address_list: self.node_network_address_list.clone(),
             micro_service_list: self.micro_service_list.clone(),
+            stage: self.stage.clone(),
         }
     }
 }

--- a/src/config/consensus_raft.rs
+++ b/src/config/consensus_raft.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::constant::CONSENSUS_RAFT;
+use crate::constant::{CONSENSUS, CONSENSUS_RAFT};
 use crate::traits::{TomlWriter, YmlWriter};
 use serde::{Deserialize, Serialize};
 
@@ -45,7 +45,7 @@ impl Consensus {
 
 impl YmlWriter for Consensus {
     fn service(&self) -> String {
-        CONSENSUS_RAFT.to_string()
+        CONSENSUS.to_string()
     }
 }
 

--- a/src/config/node_config.rs
+++ b/src/config/node_config.rs
@@ -96,6 +96,7 @@ pub struct NodeConfig {
     pub package_limit: u64,
     pub log_level: String,
     pub account: String,
+    pub cluster: String,
 }
 
 pub struct NodeConfigBuilder {
@@ -106,6 +107,7 @@ pub struct NodeConfigBuilder {
     pub package_limit: u64,
     pub log_level: String,
     pub account: String,
+    pub cluster: String,
 }
 
 impl NodeConfigBuilder {
@@ -118,6 +120,7 @@ impl NodeConfigBuilder {
             package_limit: 30000,
             log_level: "info".to_string(),
             account: "".to_string(),
+            cluster: "".to_string(),
         }
     }
     pub fn grpc_ports(&mut self, grpc_ports: GrpcPorts) -> &mut NodeConfigBuilder {
@@ -155,6 +158,11 @@ impl NodeConfigBuilder {
         self
     }
 
+    pub fn cluster(&mut self, cluster: String) -> &mut NodeConfigBuilder {
+        self.cluster = cluster;
+        self
+    }
+
     pub fn build(&self) -> NodeConfig {
         NodeConfig {
             grpc_ports: self.grpc_ports.clone(),
@@ -164,6 +172,7 @@ impl NodeConfigBuilder {
             package_limit: self.package_limit,
             log_level: self.log_level.clone(),
             account: self.account.clone(),
+            cluster: self.cluster.clone(),
         }
     }
 }

--- a/src/config/node_config.rs
+++ b/src/config/node_config.rs
@@ -96,7 +96,6 @@ pub struct NodeConfig {
     pub package_limit: u64,
     pub log_level: String,
     pub account: String,
-    pub cluster: String,
 }
 
 pub struct NodeConfigBuilder {
@@ -107,7 +106,6 @@ pub struct NodeConfigBuilder {
     pub package_limit: u64,
     pub log_level: String,
     pub account: String,
-    pub cluster: String,
 }
 
 impl NodeConfigBuilder {
@@ -120,7 +118,6 @@ impl NodeConfigBuilder {
             package_limit: 30000,
             log_level: "info".to_string(),
             account: "".to_string(),
-            cluster: "".to_string(),
         }
     }
     pub fn grpc_ports(&mut self, grpc_ports: GrpcPorts) -> &mut NodeConfigBuilder {
@@ -158,11 +155,6 @@ impl NodeConfigBuilder {
         self
     }
 
-    pub fn cluster(&mut self, cluster: String) -> &mut NodeConfigBuilder {
-        self.cluster = cluster;
-        self
-    }
-
     pub fn build(&self) -> NodeConfig {
         NodeConfig {
             grpc_ports: self.grpc_ports.clone(),
@@ -172,7 +164,6 @@ impl NodeConfigBuilder {
             package_limit: self.package_limit,
             log_level: self.log_level.clone(),
             account: self.account.clone(),
-            cluster: self.cluster.clone(),
         }
     }
 }

--- a/src/delete_node.rs
+++ b/src/delete_node.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::config::chain_config::ConfigStage;
 use crate::constant::{ACCOUNT_DIR, CERTS_DIR, CHAIN_CONFIG_FILE, NODE_CONFIG_FILE};
 use crate::error::Error;
 use crate::util::{read_chain_config, read_node_config, write_toml};
@@ -42,6 +43,10 @@ pub fn execute_delete_node(opts: DeleteNodeOpts) -> Result<(), Error> {
         &opts.config_dir, &opts.chain_name, CHAIN_CONFIG_FILE
     );
     let mut chain_config = read_chain_config(&file_name).unwrap();
+
+    if chain_config.stage == ConfigStage::Init {
+        return Err(Error::InvalidStage);
+    }
 
     let mut node_list = chain_config.node_network_address_list.clone();
 

--- a/src/delete_validator.rs
+++ b/src/delete_validator.rs
@@ -13,29 +13,27 @@
 // limitations under the License.
 
 use crate::config::chain_config::ConfigStage;
-use crate::config::chain_config::NodeNetworkAddressBuilder;
 use crate::constant::CHAIN_CONFIG_FILE;
 use crate::error::Error;
-use crate::util::{rand_string, read_chain_config, write_toml};
+use crate::util::{read_chain_config, write_toml};
 use clap::Parser;
 
 /// A subcommand for run
 #[derive(Parser, Debug, Clone)]
-pub struct SetNodeListOpts {
+pub struct DeleteValidatorOpts {
     /// set chain name
     #[clap(long = "chain-name", default_value = "test-chain")]
     pub(crate) chain_name: String,
     /// set config file directory, default means current directory
     #[clap(long = "config-dir", default_value = ".")]
     pub(crate) config_dir: String,
-    /// node list looks like localhost:40000:node0:k8s_cluster1:40000,localhost:40001:node1:k8s_cluster2:40000
-    /// last two slice is optional, none means not k8s env.
-    #[clap(long = "nodelist")]
-    pub(crate) node_list: String,
+    /// validator account
+    #[clap(long = "validator")]
+    pub(crate) validator: String,
 }
 
-/// execute set node list
-pub fn execute_set_nodelist(opts: SetNodeListOpts) -> Result<(), Error> {
+/// execute delete validator
+pub fn execute_delete_validator(opts: DeleteValidatorOpts) -> Result<(), Error> {
     // load chain_config
     let file_name = format!(
         "{}/{}/{}",
@@ -43,32 +41,20 @@ pub fn execute_set_nodelist(opts: SetNodeListOpts) -> Result<(), Error> {
     );
     let mut chain_config = read_chain_config(&file_name).unwrap();
 
-    // public and finalize is ok
-    if chain_config.stage == ConfigStage::Init {
+    if chain_config.stage != ConfigStage::Public {
         return Err(Error::InvalidStage);
     }
 
-    let node_list_str: Vec<&str> = opts.node_list.split(',').collect();
-    let node_list = node_list_str
-        .iter()
-        .map(|node| {
-            let node_network_info: Vec<&str> = node.split(':').collect();
-            let cluster = if node_network_info.len() == 3 {
-                rand_string()
-            } else {
-                node_network_info[3].to_string()
-            };
+    let mut validators = chain_config.system_config.validators.clone();
 
-            NodeNetworkAddressBuilder::new()
-                .host(node_network_info[0].to_string())
-                .port(node_network_info[1].parse::<u16>().unwrap())
-                .domain(node_network_info[2].to_string())
-                .cluster(cluster)
-                .build()
-        })
-        .collect();
+    match validators.binary_search_by(|validator| validator.cmp(&opts.validator)) {
+        Ok(index) => {
+            validators.remove(index);
+        }
+        Err(_) => panic!("Can't found validator that want to delete!"),
+    }
 
-    chain_config.set_node_network_address_list(node_list);
+    chain_config.set_validators(validators);
 
     // store chain_config
     write_toml(&chain_config, file_name);

--- a/src/env_dev.rs
+++ b/src/env_dev.rs
@@ -24,6 +24,7 @@ use crate::init_chain_config::{execute_init_chain_config, InitChainConfigOpts};
 use crate::init_node::{execute_init_node, InitNodeOpts};
 use crate::new_account::{execute_new_account, NewAccountOpts};
 use crate::set_admin::{execute_set_admin, SetAdminOpts};
+use crate::set_stage::{execute_set_stage, SetStageOpts};
 use crate::sign_csr::{execute_sign_csr, SignCSROpts};
 use crate::update_node::{execute_update_node, UpdateNodeOpts};
 use crate::util::{find_micro_service, read_chain_config};
@@ -156,6 +157,13 @@ pub fn execute_create_dev(opts: CreateDevOpts) -> Result<(), Error> {
         }
     }
 
+    execute_set_stage(SetStageOpts {
+        chain_name: opts.chain_name.clone(),
+        config_dir: opts.config_dir.clone(),
+        stage: "finalize".to_string(),
+    })
+    .unwrap();
+
     #[allow(clippy::needless_range_loop)]
     for i in 0..peers_count {
         let network_port = (50000 + i * 1000) as u16;
@@ -179,6 +187,7 @@ pub fn execute_create_dev(opts: CreateDevOpts) -> Result<(), Error> {
             log_level: opts.log_level.clone(),
             account: node.1,
             package_limit: 30000,
+            cluster: "".to_string(),
         })
         .unwrap();
 
@@ -291,6 +300,7 @@ pub fn execute_append_dev(opts: AppendDevOpts) -> Result<(), Error> {
         log_level: opts.log_level.clone(),
         account: addr,
         package_limit: 30000,
+        cluster: "".to_string(),
     })
     .unwrap();
 

--- a/src/env_dev.rs
+++ b/src/env_dev.rs
@@ -187,7 +187,6 @@ pub fn execute_create_dev(opts: CreateDevOpts) -> Result<(), Error> {
             log_level: opts.log_level.clone(),
             account: node.1,
             package_limit: 30000,
-            cluster: "".to_string(),
         })
         .unwrap();
 
@@ -300,7 +299,6 @@ pub fn execute_append_dev(opts: AppendDevOpts) -> Result<(), Error> {
         log_level: opts.log_level.clone(),
         account: addr,
         package_limit: 30000,
-        cluster: "".to_string(),
     })
     .unwrap();
 

--- a/src/env_k8s.rs
+++ b/src/env_k8s.rs
@@ -26,6 +26,7 @@ use crate::init_node::{execute_init_node, InitNodeOpts};
 use crate::new_account::{execute_new_account, NewAccountOpts};
 use crate::set_admin::{execute_set_admin, SetAdminOpts};
 use crate::set_nodelist::{execute_set_nodelist, SetNodeListOpts};
+use crate::set_stage::{execute_set_stage, SetStageOpts};
 use crate::sign_csr::{execute_sign_csr, SignCSROpts};
 use crate::update_node::{execute_update_node, UpdateNodeOpts};
 use crate::util::{find_micro_service, read_chain_config};
@@ -234,6 +235,13 @@ pub fn execute_create_k8s(opts: CreateK8sOpts) -> Result<(), Error> {
         }
     }
 
+    execute_set_stage(SetStageOpts {
+        chain_name: opts.chain_name.clone(),
+        config_dir: opts.config_dir.clone(),
+        stage: "finalize".to_string(),
+    })
+    .unwrap();
+
     // init node and update node
     for (i, node) in node_list.iter().enumerate() {
         let network_port = 50000;
@@ -258,6 +266,7 @@ pub fn execute_create_k8s(opts: CreateK8sOpts) -> Result<(), Error> {
             log_level: opts.log_level.clone(),
             account: node_account.1,
             package_limit: 30000,
+            cluster: "".to_string(),
         })
         .unwrap();
 
@@ -409,6 +418,7 @@ pub fn execute_append_k8s(opts: AppendK8sOpts) -> Result<(), Error> {
         log_level: opts.log_level.clone(),
         account: addr,
         package_limit: 30000,
+        cluster: "".to_string(),
     })
     .unwrap();
 

--- a/src/env_k8s.rs
+++ b/src/env_k8s.rs
@@ -29,12 +29,11 @@ use crate::set_nodelist::{execute_set_nodelist, SetNodeListOpts};
 use crate::set_stage::{execute_set_stage, SetStageOpts};
 use crate::sign_csr::{execute_sign_csr, SignCSROpts};
 use crate::update_node::{execute_update_node, UpdateNodeOpts};
-use crate::util::{find_micro_service, read_chain_config};
+use crate::util::{find_micro_service, rand_string, read_chain_config};
 use clap::Parser;
-use regex::{Captures, Regex};
 
 /// A subcommand for run
-#[derive(Parser, Debug, Default, Clone)]
+#[derive(Parser, Debug, Clone)]
 pub struct CreateK8sOpts {
     /// set chain name
     #[clap(long = "chain-name", default_value = "test-chain")]
@@ -64,13 +63,13 @@ pub struct CreateK8sOpts {
     #[clap(long = "block_limit", default_value = "100")]
     pub(crate) block_limit: u64,
     /// set network micro service image name (network_tls/network_p2p)
-    #[clap(long = "network_image", default_value = "network_p2p")]
+    #[clap(long = "network_image", default_value = "network_tls")]
     pub(crate) network_image: String,
     /// set network micro service image tag
     #[clap(long = "network_tag", default_value = "latest")]
     pub(crate) network_tag: String,
     /// set consensus micro service image name (consensus_bft/consensus_raft)
-    #[clap(long = "consensus_image", default_value = "consensus_raft")]
+    #[clap(long = "consensus_image", default_value = "consensus_bft")]
     pub(crate) consensus_image: String,
     /// set consensus micro service image tag
     #[clap(long = "consensus_tag", default_value = "latest")]
@@ -108,7 +107,7 @@ pub struct CreateK8sOpts {
     #[clap(long = "kms-password-list")]
     pub(crate) kms_password_list: String,
 
-    /// node list looks like localhost:40000:node0,localhost:40001:node1
+    /// node list looks like localhost:40000:node0:k8s:40000,localhost:40001:node1:k8s:40000
     #[clap(long = "nodelist")]
     pub(crate) node_list: String,
 
@@ -141,7 +140,7 @@ pub fn execute_create_k8s(opts: CreateK8sOpts) -> Result<(), Error> {
         block_interval: opts.block_interval,
         block_limit: opts.block_limit,
         network_image: opts.network_image.clone(),
-        network_tag: opts.network_image.clone(),
+        network_tag: opts.network_tag.clone(),
         consensus_image: opts.consensus_image.clone(),
         consensus_tag: opts.consensus_tag.clone(),
         executor_image: opts.executor_image.clone(),
@@ -170,10 +169,16 @@ pub fn execute_create_k8s(opts: CreateK8sOpts) -> Result<(), Error> {
         .iter()
         .map(|node| {
             let node_network_info: Vec<&str> = node.split(':').collect();
+            let cluster = if node_network_info.len() == 3 {
+                rand_string()
+            } else {
+                node_network_info[3].to_string()
+            };
             NodeNetworkAddressBuilder::new()
                 .host(node_network_info[0].to_string())
                 .port(node_network_info[1].parse::<u16>().unwrap())
                 .domain(node_network_info[2].to_string())
+                .cluster(cluster)
                 .build()
         })
         .collect();
@@ -242,8 +247,16 @@ pub fn execute_create_k8s(opts: CreateK8sOpts) -> Result<(), Error> {
     })
     .unwrap();
 
+    // reload chainconfig
+    let chain_config_file = format!(
+        "{}/{}/{}",
+        &opts.config_dir, &opts.chain_name, CHAIN_CONFIG_FILE
+    );
+
+    let chain_config = read_chain_config(&chain_config_file).unwrap();
+
     // init node and update node
-    for (i, node) in node_list.iter().enumerate() {
+    for (i, node) in chain_config.node_network_address_list.iter().enumerate() {
         let network_port = 50000;
         let domain = node.domain.to_string();
         let network_listen_port = 40000;
@@ -266,7 +279,6 @@ pub fn execute_create_k8s(opts: CreateK8sOpts) -> Result<(), Error> {
             log_level: opts.log_level.clone(),
             account: node_account.1,
             package_limit: 30000,
-            cluster: "".to_string(),
         })
         .unwrap();
 
@@ -284,7 +296,7 @@ pub fn execute_create_k8s(opts: CreateK8sOpts) -> Result<(), Error> {
     Ok(())
 }
 
-#[derive(Parser, Debug, Default, Clone)]
+#[derive(Parser, Debug, Clone)]
 pub struct AppendK8sOpts {
     /// set chain name
     #[clap(long = "chain-name", default_value = "test-chain")]
@@ -298,17 +310,9 @@ pub struct AppendK8sOpts {
     /// kms db password
     #[clap(long = "kms-password")]
     pub(crate) kms_password: String,
-    /// node network address looks like localhost:40002:node2
-    #[clap(long = "node", default_value = "")]
+    /// node network address looks like localhost:40002:node2:k8s:40000
+    #[clap(long = "node")]
     pub(crate) node: String,
-}
-
-fn find_num_plus_one(s: String) -> String {
-    let r2 = Regex::new(r"(\d+)").unwrap();
-    r2.replace_all(&s, |c: &Captures| {
-        (c[0].to_string().parse::<u32>().unwrap() + 1).to_string()
-    })
-    .to_string()
 }
 
 /// append a new node into chain
@@ -329,37 +333,25 @@ pub fn execute_append_k8s(opts: AppendK8sOpts) -> Result<(), Error> {
     .unwrap();
 
     // parse node network info
-    let new_node;
-    let mut node_str = String::new();
-    if opts.node == *"" {
-        let old_node_network_info = &chain_config.node_network_address_list
-            [chain_config.node_network_address_list.len() - 1];
-        let host = find_num_plus_one(old_node_network_info.host.clone());
-        let port = old_node_network_info.port + 1;
-        let domain = find_num_plus_one(old_node_network_info.domain.clone());
-        new_node = NodeNetworkAddressBuilder::new()
-            .host(host.clone())
-            .port(port)
-            .domain(domain.clone())
-            .build();
-        node_str = host + &String::from(":") + &port.to_string() + &String::from(":") + &domain;
+    let node_network_info: Vec<&str> = opts.node.split(':').collect();
+    let cluster = if node_network_info.len() == 3 {
+        rand_string()
     } else {
-        let node_network_info: Vec<&str> = opts.node.split(':').collect();
-        new_node = NodeNetworkAddressBuilder::new()
-            .host(node_network_info[0].to_string())
-            .port(node_network_info[1].parse::<u16>().unwrap())
-            .domain(node_network_info[2].to_string())
-            .build();
-    }
+        node_network_info[3].to_string()
+    };
+
+    let new_node = NodeNetworkAddressBuilder::new()
+        .host(node_network_info[0].to_string())
+        .port(node_network_info[1].parse::<u16>().unwrap())
+        .domain(node_network_info[2].to_string())
+        .cluster(cluster)
+        .build();
 
     // append node
     execute_append_node(AppendNodeOpts {
         chain_name: opts.chain_name.clone(),
         config_dir: opts.config_dir.clone(),
-        node: match node_str {
-            node_str if node_str.is_empty() => opts.node.clone(),
-            _ => node_str,
-        },
+        node: opts.node.clone(),
     })
     .unwrap();
 
@@ -389,7 +381,7 @@ pub fn execute_append_k8s(opts: AppendK8sOpts) -> Result<(), Error> {
         execute_update_node(UpdateNodeOpts {
             chain_name: opts.chain_name.clone(),
             config_dir: opts.config_dir.clone(),
-            domain,
+            domain: domain.clone(),
             is_stdout: true,
             config_name: "config.toml".to_string(),
             is_old: true,
@@ -418,13 +410,12 @@ pub fn execute_append_k8s(opts: AppendK8sOpts) -> Result<(), Error> {
         log_level: opts.log_level.clone(),
         account: addr,
         package_limit: 30000,
-        cluster: "".to_string(),
     })
     .unwrap();
 
     execute_update_node(UpdateNodeOpts {
         chain_name: opts.chain_name.clone(),
-        config_dir: opts.config_dir,
+        config_dir: opts.config_dir.clone(),
         domain,
         is_stdout: true,
         config_name: "config.toml".to_string(),
@@ -473,7 +464,7 @@ pub fn execute_delete_k8s(opts: DeleteK8sOpts) -> Result<(), Error> {
         execute_update_node(UpdateNodeOpts {
             chain_name: opts.chain_name.clone(),
             config_dir: opts.config_dir.clone(),
-            domain,
+            domain: domain.clone(),
             is_stdout: true,
             config_name: "config.toml".to_string(),
             is_old: true,
@@ -482,51 +473,4 @@ pub fn execute_delete_k8s(opts: DeleteK8sOpts) -> Result<(), Error> {
     }
 
     Ok(())
-}
-
-#[cfg(test)]
-mod test {
-    use crate::env_k8s::{execute_append_k8s, execute_create_k8s, AppendK8sOpts, CreateK8sOpts};
-    use regex::{Captures, Regex};
-
-    #[test]
-    fn test_create() {
-        execute_create_k8s(CreateK8sOpts {
-            chain_name: "localcluster".to_string(),
-            config_dir: ".".to_string(),
-            admin: "0x74f1bf7351bf97d7217a9232aa0074e303018f7d".to_string(),
-            kms_password_list: "dasd,dsad".to_string(),
-            node_list: "node0:40000:node0,node1:40001:node1".to_string(),
-            network_image: "network_p2p".to_string(),
-            consensus_image: "consensus_raft".to_string(),
-            storage_image: "storage_rocksdb".to_string(),
-            executor_image: "executor_evm".to_string(),
-            controller_image: "controller".to_string(),
-            kms_image: "kms_sm".to_string(),
-            ..Default::default()
-        })
-        .unwrap();
-    }
-
-    #[test]
-    fn test_append() {
-        execute_append_k8s(AppendK8sOpts {
-            chain_name: "localcluster".to_string(),
-            config_dir: ".".to_string(),
-            log_level: "info".to_string(),
-            kms_password: "dasd".to_string(),
-            ..Default::default()
-        })
-        .unwrap();
-    }
-
-    #[test]
-    fn test_replace_num() {
-        let s = "node21-1";
-        let r2 = Regex::new(r"(\d+)").unwrap();
-        let s2 = r2.replace_all(s, |c: &Captures| {
-            (c[0].to_string().parse::<u32>().unwrap() + 1).to_string()
-        });
-        println!("{}", s2);
-    }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -18,4 +18,5 @@ pub enum Error {
     DupChainName,
     ListLenNotMatch,
     InvalidStage,
+    FileNoFound,
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -17,4 +17,5 @@
 pub enum Error {
     DupChainName,
     ListLenNotMatch,
+    InvalidStage,
 }

--- a/src/import_account.rs
+++ b/src/import_account.rs
@@ -28,7 +28,7 @@ use crate::{
     util::{find_micro_service, read_chain_config, write_file},
 };
 
-/// A subcommand for import account, only kms_sm is supported
+/// A subcommand for import account
 #[derive(Parser, Debug, Clone)]
 pub struct ImportAccountOpts {
     /// set chain name

--- a/src/import_ca.rs
+++ b/src/import_ca.rs
@@ -1,0 +1,67 @@
+// Copyright Rivtower Technologies LLC.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::constant::{CA_CERT_DIR, CERT_PEM, KEY_PEM};
+use crate::error::Error;
+use crate::util::read_file;
+use clap::Parser;
+use std::fs;
+use std::path::Path;
+
+/// A subcommand for run
+#[derive(Parser, Debug, Clone)]
+pub struct ImportCAOpts {
+    /// set chain name
+    #[clap(long = "chain-name", default_value = "test-chain")]
+    pub(crate) chain_name: String,
+    /// set config file directory, default means current directory
+    #[clap(long = "config-dir", default_value = ".")]
+    pub(crate) config_dir: String,
+    /// set path of ca cert file(pem)
+    #[clap(long = "ca-cert")]
+    pub(crate) ca_cert_path: String,
+    /// set path of ca key file(pem)
+    #[clap(long = "ca-key")]
+    pub(crate) ca_key_path: String,
+}
+
+/// execute import ca
+pub fn execute_import_ca(opts: ImportCAOpts) -> Result<(String, String), Error> {
+    if !Path::new(&opts.ca_cert_path).exists() {
+        return Err(Error::FileNoFound);
+    }
+
+    if !Path::new(&opts.ca_key_path).exists() {
+        return Err(Error::FileNoFound);
+    }
+
+    let cert_path = format!(
+        "{}/{}/{}/{}",
+        &opts.config_dir, &opts.chain_name, CA_CERT_DIR, CERT_PEM
+    );
+
+    fs::copy(&opts.ca_cert_path, &cert_path).unwrap();
+
+    let key_path = format!(
+        "{}/{}/{}/{}",
+        &opts.config_dir, &opts.chain_name, CA_CERT_DIR, KEY_PEM
+    );
+
+    fs::copy(&opts.ca_key_path, &key_path).unwrap();
+
+    let ca_cert_pem = read_file(cert_path).unwrap();
+    let ca_key_pem = read_file(key_path).unwrap();
+
+    Ok((ca_cert_pem, ca_key_pem))
+}

--- a/src/import_cert.rs
+++ b/src/import_cert.rs
@@ -1,0 +1,69 @@
+// Copyright Rivtower Technologies LLC.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::constant::{CERTS_DIR, CERT_PEM, KEY_PEM};
+use crate::error::Error;
+use crate::util::read_file;
+use clap::Parser;
+use std::fs;
+use std::path::Path;
+
+/// A subcommand for run
+#[derive(Parser, Debug, Clone)]
+pub struct ImportCertOpts {
+    /// set chain name
+    #[clap(long = "chain-name", default_value = "test-chain")]
+    pub(crate) chain_name: String,
+    /// set config file directory, default means current directory
+    #[clap(long = "config-dir", default_value = ".")]
+    pub(crate) config_dir: String,
+    /// domain of node
+    #[clap(long = "domain")]
+    pub(crate) domain: String,
+    /// set path of cert file(pem)
+    #[clap(long = "cert")]
+    pub(crate) cert_path: String,
+    /// set path of key file(pem)
+    #[clap(long = "key")]
+    pub(crate) key_path: String,
+}
+
+/// execute create csr
+pub fn execute_import_cert(opts: ImportCertOpts) -> Result<(String, String), Error> {
+    if !Path::new(&opts.cert_path).exists() {
+        return Err(Error::FileNoFound);
+    }
+
+    if !Path::new(&opts.key_path).exists() {
+        return Err(Error::FileNoFound);
+    }
+
+    // gen a folder to store cert info
+    let path = format!(
+        "{}/{}/{}/{}",
+        &opts.config_dir, &opts.chain_name, CERTS_DIR, &opts.domain
+    );
+    fs::create_dir_all(&path).unwrap();
+
+    let cert_pem_path = format!("{}/{}", &path, CERT_PEM);
+    fs::copy(&opts.cert_path, &cert_pem_path).unwrap();
+
+    let key_pem_path = format!("{}/{}", &path, KEY_PEM);
+    fs::copy(&opts.key_path, &key_pem_path).unwrap();
+
+    let cert_pem = read_file(cert_pem_path).unwrap();
+    let key_pem = read_file(key_pem_path).unwrap();
+
+    Ok((cert_pem, key_pem))
+}

--- a/src/import_cert.rs
+++ b/src/import_cert.rs
@@ -39,7 +39,7 @@ pub struct ImportCertOpts {
     pub(crate) key_path: String,
 }
 
-/// execute create csr
+/// execute import cert
 pub fn execute_import_cert(opts: ImportCertOpts) -> Result<(String, String), Error> {
     if !Path::new(&opts.cert_path).exists() {
         return Err(Error::FileNoFound);

--- a/src/init_chain_config.rs
+++ b/src/init_chain_config.rs
@@ -52,13 +52,13 @@ pub struct InitChainConfigOpts {
     #[clap(long = "block_limit", default_value = "100")]
     pub(crate) block_limit: u64,
     /// set network micro service image name (network_tls/network_p2p)
-    #[clap(long = "network_image", default_value = "network_p2p")]
+    #[clap(long = "network_image", default_value = "network_tls")]
     pub(crate) network_image: String,
     /// set network micro service image tag
     #[clap(long = "network_tag", default_value = "latest")]
     pub(crate) network_tag: String,
     /// set consensus micro service image name (consensus_bft/consensus_raft)
-    #[clap(long = "consensus_image", default_value = "consensus_raft")]
+    #[clap(long = "consensus_image", default_value = "consensus_bft")]
     pub(crate) consensus_image: String,
     /// set consensus micro service image tag
     #[clap(long = "consensus_tag", default_value = "latest")]

--- a/src/init_node.rs
+++ b/src/init_node.rs
@@ -15,9 +15,8 @@
 use crate::config::node_config::{GrpcPortsBuilder, NodeConfigBuilder};
 use crate::constant::NODE_CONFIG_FILE;
 use crate::error::Error;
-use crate::util::write_toml;
+use crate::util::{copy_dir_all, write_toml};
 use clap::Parser;
-use std::fs;
 
 /// A subcommand for run
 #[derive(Parser, Debug, Clone)]
@@ -90,7 +89,8 @@ pub fn execute_init_node(opts: InitNodeOpts) -> Result<(), Error> {
         .build();
 
     let node_dir = format!("{}/{}-{}", &opts.config_dir, &opts.chain_name, &opts.domain);
-    fs::create_dir_all(&node_dir).unwrap();
+    let from = format!("{}/{}", &opts.config_dir, &opts.chain_name);
+    copy_dir_all(&from, &node_dir).unwrap();
 
     let file_name = format!("{}/{}", &node_dir, NODE_CONFIG_FILE);
     write_toml(&node_config, file_name);

--- a/src/init_node.rs
+++ b/src/init_node.rs
@@ -16,7 +16,7 @@ use crate::config::chain_config::ConfigStage;
 use crate::config::node_config::{GrpcPortsBuilder, NodeConfigBuilder};
 use crate::constant::{CHAIN_CONFIG_FILE, NODE_CONFIG_FILE};
 use crate::error::Error;
-use crate::util::{copy_dir_all, read_chain_config, write_toml};
+use crate::util::{copy_dir_all, rand_string, read_chain_config, write_toml};
 use clap::Parser;
 use std::path::Path;
 
@@ -68,6 +68,9 @@ pub struct InitNodeOpts {
     /// account of node
     #[clap(long = "account")]
     pub(crate) account: String,
+    /// cluster name
+    #[clap(long = "cluster", default_value = "")]
+    pub(crate) cluster: String,
 }
 
 /// execute set validators
@@ -87,6 +90,12 @@ pub fn execute_init_node(opts: InitNodeOpts) -> Result<(), Error> {
         return Err(Error::InvalidStage);
     }
 
+    let cluster = if opts.cluster.is_empty() {
+        rand_string()
+    } else {
+        opts.cluster
+    };
+
     let grpc_ports = GrpcPortsBuilder::new()
         .network_port(opts.network_port)
         .consensus_port(opts.consensus_port)
@@ -103,6 +112,7 @@ pub fn execute_init_node(opts: InitNodeOpts) -> Result<(), Error> {
         .package_limit(opts.package_limit)
         .log_level(opts.log_level)
         .account(opts.account)
+        .cluster(cluster)
         .build();
 
     let node_dir = format!("{}/{}-{}", &opts.config_dir, &opts.chain_name, &opts.domain);

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,6 +42,7 @@ use crate::set_stage::{execute_set_stage, SetStageOpts};
 use crate::set_validators::{execute_set_validators, SetValidatorsOpts};
 use crate::sign_csr::{execute_sign_csr, SignCSROpts};
 use crate::update_node::{execute_update_node, UpdateNodeOpts};
+use crate::update_yaml::{execute_update_yaml, UpdateYamlOpts};
 
 mod append_node;
 mod append_validator;
@@ -69,6 +70,7 @@ mod set_validators;
 mod sign_csr;
 mod traits;
 mod update_node;
+mod update_yaml;
 mod util;
 
 #[derive(Parser)]
@@ -159,6 +161,9 @@ enum SubCommand {
     // import node cert
     #[clap(name = "import-cert")]
     ImportCert(ImportCertOpts),
+    // update k8s yaml
+    #[clap(name = "update-yaml")]
+    UpdateYaml(UpdateYamlOpts),
 }
 
 fn main() {
@@ -193,5 +198,6 @@ fn main() {
         SubCommand::SetStage(opts) => execute_set_stage(opts).unwrap(),
         SubCommand::ImportCA(opts) => execute_import_ca(opts).map(|_| ()).unwrap(),
         SubCommand::ImportCert(opts) => execute_import_cert(opts).map(|_| ()).unwrap(),
+        SubCommand::UpdateYaml(opts) => execute_update_yaml(opts).unwrap(),
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,6 +36,7 @@ use crate::migrate::{execute_migrate, MigrateOpts};
 use crate::new_account::{execute_new_account, NewAccountOpts};
 use crate::set_admin::{execute_set_admin, SetAdminOpts};
 use crate::set_nodelist::{execute_set_nodelist, SetNodeListOpts};
+use crate::set_stage::{execute_set_stage, SetStageOpts};
 use crate::set_validators::{execute_set_validators, SetValidatorsOpts};
 use crate::sign_csr::{execute_sign_csr, SignCSROpts};
 use crate::update_node::{execute_update_node, UpdateNodeOpts};
@@ -59,6 +60,7 @@ mod migrate;
 mod new_account;
 mod set_admin;
 mod set_nodelist;
+mod set_stage;
 mod set_validators;
 mod sign_csr;
 mod traits;
@@ -144,6 +146,9 @@ enum SubCommand {
     /// migrate CITA-Cloud chain from 6.1.0 to 6.3.0
     #[clap(name = "migrate")]
     Migrate(MigrateOpts),
+    // set stage
+    #[clap(name = "set-stage")]
+    SetStage(SetStageOpts),
 }
 
 fn main() {
@@ -175,5 +180,6 @@ fn main() {
         SubCommand::AppendK8s(opts) => execute_append_k8s(opts).unwrap(),
         SubCommand::DeleteK8s(opts) => execute_delete_k8s(opts).unwrap(),
         SubCommand::Migrate(opts) => execute_migrate(opts).unwrap(),
+        SubCommand::SetStage(opts) => execute_set_stage(opts).unwrap(),
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,7 @@ use crate::create_ca::{execute_create_ca, CreateCAOpts};
 use crate::create_csr::{execute_create_csr, CreateCSROpts};
 use crate::delete_chain::{execute_delete_chain, DeleteChainOpts};
 use crate::delete_node::{execute_delete_node, DeleteNodeOpts};
+use crate::delete_validator::{execute_delete_validator, DeleteValidatorOpts};
 use crate::env_dev::{
     execute_append_dev, execute_create_dev, execute_delete_dev, AppendDevOpts, CreateDevOpts,
     DeleteDevOpts,
@@ -52,6 +53,7 @@ mod create_ca;
 mod create_csr;
 mod delete_chain;
 mod delete_node;
+mod delete_validator;
 mod env_dev;
 mod env_k8s;
 mod error;
@@ -152,18 +154,21 @@ enum SubCommand {
     /// migrate CITA-Cloud chain from 6.1.0 to 6.3.0
     #[clap(name = "migrate")]
     Migrate(MigrateOpts),
-    // set stage
+    /// set stage
     #[clap(name = "set-stage")]
     SetStage(SetStageOpts),
-    // import ca
+    /// import ca
     #[clap(name = "import-ca")]
     ImportCA(ImportCAOpts),
-    // import node cert
+    /// import node cert
     #[clap(name = "import-cert")]
     ImportCert(ImportCertOpts),
-    // update k8s yaml
+    /// update k8s yaml
     #[clap(name = "update-yaml")]
     UpdateYaml(UpdateYamlOpts),
+    /// delete a validator from chain
+    #[clap(name = "delete-validator")]
+    DeleteValidator(DeleteValidatorOpts),
 }
 
 fn main() {
@@ -199,5 +204,6 @@ fn main() {
         SubCommand::ImportCA(opts) => execute_import_ca(opts).map(|_| ()).unwrap(),
         SubCommand::ImportCert(opts) => execute_import_cert(opts).map(|_| ()).unwrap(),
         SubCommand::UpdateYaml(opts) => execute_update_yaml(opts).unwrap(),
+        SubCommand::DeleteValidator(opts) => execute_delete_validator(opts).unwrap(),
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,6 +29,8 @@ use crate::env_k8s::{
     DeleteK8sOpts,
 };
 use crate::import_account::{execute_import_account, ImportAccountOpts};
+use crate::import_ca::{execute_import_ca, ImportCAOpts};
+use crate::import_cert::{execute_import_cert, ImportCertOpts};
 use crate::init_chain::{execute_init_chain, InitChainOpts};
 use crate::init_chain_config::{execute_init_chain_config, InitChainConfigOpts};
 use crate::init_node::{execute_init_node, InitNodeOpts};
@@ -53,6 +55,8 @@ mod env_dev;
 mod env_k8s;
 mod error;
 mod import_account;
+mod import_ca;
+mod import_cert;
 mod init_chain;
 mod init_chain_config;
 mod init_node;
@@ -149,6 +153,12 @@ enum SubCommand {
     // set stage
     #[clap(name = "set-stage")]
     SetStage(SetStageOpts),
+    // import ca
+    #[clap(name = "import-ca")]
+    ImportCA(ImportCAOpts),
+    // import node cert
+    #[clap(name = "import-cert")]
+    ImportCert(ImportCertOpts),
 }
 
 fn main() {
@@ -181,5 +191,7 @@ fn main() {
         SubCommand::DeleteK8s(opts) => execute_delete_k8s(opts).unwrap(),
         SubCommand::Migrate(opts) => execute_migrate(opts).unwrap(),
         SubCommand::SetStage(opts) => execute_set_stage(opts).unwrap(),
+        SubCommand::ImportCA(opts) => execute_import_ca(opts).map(|_| ()).unwrap(),
+        SubCommand::ImportCert(opts) => execute_import_cert(opts).map(|_| ()).unwrap(),
     }
 }

--- a/src/migrate.rs
+++ b/src/migrate.rs
@@ -34,6 +34,7 @@ use crate::{
     init_node::{execute_init_node, InitNodeOpts},
     set_admin::{execute_set_admin, SetAdminOpts},
     set_nodelist::{execute_set_nodelist, SetNodeListOpts},
+    set_stage::{execute_set_stage, SetStageOpts},
     set_validators::{execute_set_validators, SetValidatorsOpts},
     sign_csr::{execute_sign_csr, SignCSROpts},
     update_node::{execute_update_node, UpdateNodeOpts},
@@ -298,6 +299,8 @@ fn generate_new_node_config(
         package_limit: DEFAULT_PACKAGE_LIMIT,
 
         log_level: "info".into(),
+
+        cluster: "".to_string(),
     })
     .unwrap();
 
@@ -432,6 +435,13 @@ where
     execute_create_ca(CreateCAOpts {
         chain_name: chain_name.into(),
         config_dir: config_dir.into(),
+    })
+    .unwrap();
+
+    execute_set_stage(SetStageOpts {
+        chain_name: chain_name.into(),
+        config_dir: config_dir.into(),
+        stage: "finalize".into(),
     })
     .unwrap();
 

--- a/src/migrate.rs
+++ b/src/migrate.rs
@@ -299,8 +299,6 @@ fn generate_new_node_config(
         package_limit: DEFAULT_PACKAGE_LIMIT,
 
         log_level: "info".into(),
-
-        cluster: "".to_string(),
     })
     .unwrap();
 

--- a/src/new_account.rs
+++ b/src/new_account.rs
@@ -41,7 +41,6 @@ pub fn execute_new_account(opts: NewAccountOpts) -> Result<(u64, String), Error>
     );
     let _chain_config = read_chain_config(&file_name).unwrap();
 
-    // Now only support kms_sm
     let is_eth = find_micro_service(&_chain_config, KMS_ETH);
 
     // new account in base folder

--- a/src/set_admin.rs
+++ b/src/set_admin.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::config::chain_config::ConfigStage;
 use crate::constant::CHAIN_CONFIG_FILE;
 use crate::error::Error;
 use crate::util::{read_chain_config, write_toml};
@@ -40,9 +41,14 @@ pub fn execute_set_admin(opts: SetAdminOpts) -> Result<(), Error> {
     );
     let mut chain_config = read_chain_config(&file_name).unwrap();
 
+    if chain_config.stage != ConfigStage::Init {
+        return Err(Error::InvalidStage);
+    }
+
     let admin = opts.admin;
 
     chain_config.set_admin(admin);
+    chain_config.set_stage(ConfigStage::Public);
 
     // store chain_config
     write_toml(&chain_config, file_name);

--- a/src/set_nodelist.rs
+++ b/src/set_nodelist.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::config::chain_config::ConfigStage;
 use crate::config::chain_config::NodeNetworkAddressBuilder;
 use crate::constant::CHAIN_CONFIG_FILE;
 use crate::error::Error;
@@ -40,6 +41,11 @@ pub fn execute_set_nodelist(opts: SetNodeListOpts) -> Result<(), Error> {
         &opts.config_dir, &opts.chain_name, CHAIN_CONFIG_FILE
     );
     let mut chain_config = read_chain_config(&file_name).unwrap();
+
+    // public and finalize is ok
+    if chain_config.stage == ConfigStage::Init {
+        return Err(Error::InvalidStage);
+    }
 
     let node_list_str: Vec<&str> = opts.node_list.split(',').collect();
     let node_list = node_list_str

--- a/src/set_stage.rs
+++ b/src/set_stage.rs
@@ -15,25 +15,25 @@
 use crate::config::chain_config::ConfigStage;
 use crate::constant::CHAIN_CONFIG_FILE;
 use crate::error::Error;
-use crate::util::{check_address, read_chain_config, write_toml};
+use crate::util::{read_chain_config, write_toml};
 use clap::Parser;
 
 /// A subcommand for run
 #[derive(Parser, Debug, Clone)]
-pub struct AppendValidatorOpts {
+pub struct SetStageOpts {
     /// set chain name
     #[clap(long = "chain-name", default_value = "test-chain")]
     pub(crate) chain_name: String,
     /// set config file directory, default means current directory
     #[clap(long = "config-dir", default_value = ".")]
     pub(crate) config_dir: String,
-    /// validator account
-    #[clap(long = "validator")]
-    pub(crate) validator: String,
+    /// set stage public or finalize
+    #[clap(long = "stage")]
+    pub(crate) stage: String,
 }
 
-/// execute set validators
-pub fn execute_append_validator(opts: AppendValidatorOpts) -> Result<(), Error> {
+/// execute set admin
+pub fn execute_set_stage(opts: SetStageOpts) -> Result<(), Error> {
     // load chain_config
     let file_name = format!(
         "{}/{}/{}",
@@ -41,15 +41,13 @@ pub fn execute_append_validator(opts: AppendValidatorOpts) -> Result<(), Error> 
     );
     let mut chain_config = read_chain_config(&file_name).unwrap();
 
-    if chain_config.stage != ConfigStage::Public {
+    if opts.stage == "public" {
+        chain_config.stage = ConfigStage::Public;
+    } else if opts.stage == "finalize" {
+        chain_config.stage = ConfigStage::Finalize;
+    } else {
         return Err(Error::InvalidStage);
     }
-
-    let mut validators = chain_config.system_config.validators.clone();
-
-    validators.push(check_address(&opts.validator[..]).to_string());
-
-    chain_config.set_validators(validators);
 
     // store chain_config
     write_toml(&chain_config, file_name);

--- a/src/set_stage.rs
+++ b/src/set_stage.rs
@@ -27,12 +27,12 @@ pub struct SetStageOpts {
     /// set config file directory, default means current directory
     #[clap(long = "config-dir", default_value = ".")]
     pub(crate) config_dir: String,
-    /// set stage public or finalize
-    #[clap(long = "stage")]
+    /// set stage init/public/finalize
+    #[clap(long = "stage", default_value = "finalize")]
     pub(crate) stage: String,
 }
 
-/// execute set admin
+/// execute set stage
 pub fn execute_set_stage(opts: SetStageOpts) -> Result<(), Error> {
     // load chain_config
     let file_name = format!(
@@ -41,7 +41,9 @@ pub fn execute_set_stage(opts: SetStageOpts) -> Result<(), Error> {
     );
     let mut chain_config = read_chain_config(&file_name).unwrap();
 
-    if opts.stage == "public" {
+    if opts.stage == "init" {
+        chain_config.stage = ConfigStage::Init;
+    } else if opts.stage == "public" {
         chain_config.stage = ConfigStage::Public;
     } else if opts.stage == "finalize" {
         chain_config.stage = ConfigStage::Finalize;

--- a/src/set_validators.rs
+++ b/src/set_validators.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::config::chain_config::ConfigStage;
 use crate::constant::CHAIN_CONFIG_FILE;
 use crate::error::Error;
 use crate::util::{check_address, read_chain_config, write_toml};
@@ -39,6 +40,10 @@ pub fn execute_set_validators(opts: SetValidatorsOpts) -> Result<(), Error> {
         &opts.config_dir, &opts.chain_name, CHAIN_CONFIG_FILE
     );
     let mut chain_config = read_chain_config(&file_name).unwrap();
+
+    if chain_config.stage != ConfigStage::Public {
+        return Err(Error::InvalidStage);
+    }
 
     let validators: Vec<&str> = opts.validators.split(',').collect();
 

--- a/src/sign_csr.rs
+++ b/src/sign_csr.rs
@@ -31,7 +31,7 @@ pub struct SignCSROpts {
     pub(crate) domain: String,
 }
 
-/// execute sign cert
+/// execute sign csr
 pub fn execute_sign_csr(opts: SignCSROpts) -> Result<String, Error> {
     // load ca cert
     let ca_cert_path = format!(

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -48,7 +48,7 @@ pub trait TomlWriter {
 pub trait YmlWriter {
     fn service(&self) -> String;
 
-    fn write_log4rs(&self, path: &str, _is_stdout: bool)
+    fn write_log4rs(&self, path: &str, _is_stdout: bool, log_level: &str)
     where
         Self: Serialize,
     {
@@ -89,7 +89,7 @@ root:
     - stdout
     - journey-service
 "#,
-                service, service, "info"
+                service, service, log_level
             ),
         )
         .unwrap();

--- a/src/update_node.rs
+++ b/src/update_node.rs
@@ -70,6 +70,13 @@ pub fn execute_update_node(opts: UpdateNodeOpts) -> Result<(), Error> {
     let file_name = format!("{}/{}", &node_dir, CHAIN_CONFIG_FILE);
     let chain_config = read_chain_config(&file_name).unwrap();
 
+    let mut local_cluster = "";
+    for node_network_address in &chain_config.node_network_address_list {
+        if node_network_address.domain == opts.domain {
+            local_cluster = &node_network_address.cluster;
+        }
+    }
+
     // because this file write by one and one section
     // so write mode must be append
     // so if you want rewrite, delete old config file at first
@@ -89,7 +96,6 @@ pub fn execute_update_node(opts: UpdateNodeOpts) -> Result<(), Error> {
 
     // network config file
     // if network_p2p
-    let local_cluster = &node_config.cluster;
     if find_micro_service(&chain_config, NETWORK_P2P) {
         let mut uris: Vec<P2P_PeerConfig> = Vec::new();
         for node_network_address in &chain_config.node_network_address_list {

--- a/src/update_node.rs
+++ b/src/update_node.rs
@@ -59,29 +59,27 @@ pub struct UpdateNodeOpts {
 /// generate node config files by chain_config and node_config
 pub fn execute_update_node(opts: UpdateNodeOpts) -> Result<(), Error> {
     let is_old = opts.is_old;
-    // load chain_config
-    let file_name = format!(
-        "{}/{}/{}",
-        &opts.config_dir, &opts.chain_name, CHAIN_CONFIG_FILE
-    );
-    let chain_config = read_chain_config(&file_name).unwrap();
 
     let node_dir = format!("{}/{}-{}", &opts.config_dir, &opts.chain_name, &opts.domain);
-    let config_file_name = format!("{}/{}", &node_dir, opts.config_name);
-
-    // delete old config file
-    let _ = fs::remove_file(&config_file_name);
 
     // load node_config
     let file_name = format!("{}/{}", &node_dir, NODE_CONFIG_FILE);
     let node_config = read_node_config(file_name).unwrap();
 
-    // move account files info node folder
+    // load chain_config
+    let file_name = format!("{}/{}", &node_dir, CHAIN_CONFIG_FILE);
+    let chain_config = read_chain_config(&file_name).unwrap();
+
+    // delete old config file
+    let config_file_name = format!("{}/{}", &node_dir, opts.config_name);
+    let _ = fs::remove_file(&config_file_name);
+
+    // copy account files
     // only for new node
     if !is_old {
         let from = format!(
-            "{}/{}/{}/{}/{}",
-            &opts.config_dir, &opts.chain_name, ACCOUNT_DIR, &node_config.account, KMS_DB
+            "{}/{}/{}/{}",
+            &node_dir, ACCOUNT_DIR, &node_config.account, KMS_DB
         );
         let to = format!("{}/{}", &node_dir, KMS_DB);
         fs::copy(from, to).unwrap();
@@ -124,19 +122,15 @@ pub fn execute_update_node(opts: UpdateNodeOpts) -> Result<(), Error> {
             }
         }
         // load cert
-        let ca_cert = read_file(format!(
-            "{}/{}/{}/{}",
-            &opts.config_dir, &opts.chain_name, CA_CERT_DIR, CERT_PEM
-        ))
-        .unwrap();
+        let ca_cert = read_file(format!("{}/{}/{}", &node_dir, CA_CERT_DIR, CERT_PEM)).unwrap();
         let cert = read_file(format!(
-            "{}/{}/{}/{}/{}",
-            &opts.config_dir, &opts.chain_name, CERTS_DIR, &opts.domain, CERT_PEM
+            "{}/{}/{}/{}",
+            &node_dir, CERTS_DIR, &opts.domain, CERT_PEM
         ))
         .unwrap();
         let key = read_file(format!(
-            "{}/{}/{}/{}/{}",
-            &opts.config_dir, &opts.chain_name, CERTS_DIR, &opts.domain, KEY_PEM
+            "{}/{}/{}/{}",
+            &node_dir, CERTS_DIR, &opts.domain, KEY_PEM
         ))
         .unwrap();
 

--- a/src/update_node.rs
+++ b/src/update_node.rs
@@ -70,7 +70,9 @@ pub fn execute_update_node(opts: UpdateNodeOpts) -> Result<(), Error> {
     let file_name = format!("{}/{}", &node_dir, CHAIN_CONFIG_FILE);
     let chain_config = read_chain_config(&file_name).unwrap();
 
-    // delete old config file
+    // because this file write by one and one section
+    // so write mode must be append
+    // so if you want rewrite, delete old config file at first
     let config_file_name = format!("{}/{}", &node_dir, opts.config_name);
     let _ = fs::remove_file(&config_file_name);
 

--- a/src/update_node.rs
+++ b/src/update_node.rs
@@ -107,7 +107,7 @@ pub fn execute_update_node(opts: UpdateNodeOpts) -> Result<(), Error> {
         network_config.write(&config_file_name);
         // only for new node
         if !is_old {
-            network_config.write_log4rs(&node_dir, opts.is_stdout);
+            network_config.write_log4rs(&node_dir, opts.is_stdout, &node_config.log_level);
         }
     } else if find_micro_service(&chain_config, NETWORK_TLS) {
         let mut tls_peers: Vec<TLS_PeerConfig> = Vec::new();
@@ -145,7 +145,7 @@ pub fn execute_update_node(opts: UpdateNodeOpts) -> Result<(), Error> {
         network_config.write(&config_file_name);
         // only for new node
         if !is_old {
-            network_config.write_log4rs(&node_dir, opts.is_stdout);
+            network_config.write_log4rs(&node_dir, opts.is_stdout, &node_config.log_level);
         }
     } else {
         panic!("unsupport network service");
@@ -172,7 +172,7 @@ pub fn execute_update_node(opts: UpdateNodeOpts) -> Result<(), Error> {
         consensus_config.write(&config_file_name);
         // only for new node
         if !is_old {
-            consensus_config.write_log4rs(&node_dir, opts.is_stdout);
+            consensus_config.write_log4rs(&node_dir, opts.is_stdout, &node_config.log_level);
         }
     } else {
         panic!("unsupport consensus service");
@@ -185,7 +185,7 @@ pub fn execute_update_node(opts: UpdateNodeOpts) -> Result<(), Error> {
         executor_config.write(&config_file_name);
         // only for new node
         if !is_old {
-            executor_config.write_log4rs(&node_dir, opts.is_stdout);
+            executor_config.write_log4rs(&node_dir, opts.is_stdout, &node_config.log_level);
         }
     } else {
         panic!("unsupport executor service");
@@ -201,7 +201,7 @@ pub fn execute_update_node(opts: UpdateNodeOpts) -> Result<(), Error> {
         storage_config.write(&config_file_name);
         // only for new node
         if !is_old {
-            storage_config.write_log4rs(&node_dir, opts.is_stdout);
+            storage_config.write_log4rs(&node_dir, opts.is_stdout, &node_config.log_level);
         }
     } else {
         panic!("unsupport storage service");
@@ -225,7 +225,7 @@ pub fn execute_update_node(opts: UpdateNodeOpts) -> Result<(), Error> {
         controller_config.write(&config_file_name);
         // only for new node
         if !is_old {
-            controller_config.write_log4rs(&node_dir, opts.is_stdout);
+            controller_config.write_log4rs(&node_dir, opts.is_stdout, &node_config.log_level);
         }
     } else {
         panic!("unsupport controller service");
@@ -238,14 +238,14 @@ pub fn execute_update_node(opts: UpdateNodeOpts) -> Result<(), Error> {
         kms_config.write(&config_file_name);
         // only for new node
         if !is_old {
-            kms_config.write_log4rs(&node_dir, opts.is_stdout);
+            kms_config.write_log4rs(&node_dir, opts.is_stdout, &node_config.log_level);
         }
     } else if find_micro_service(&chain_config, KMS_ETH) {
         let kms_config = KmsEthConfig::new(node_config.grpc_ports.kms_port, node_config.db_key);
         kms_config.write(&config_file_name);
         // only for new node
         if !is_old {
-            kms_config.write_log4rs(&node_dir, opts.is_stdout);
+            kms_config.write_log4rs(&node_dir, opts.is_stdout, &node_config.log_level);
         }
     } else {
         panic!("unsupport kms service");

--- a/src/update_node.rs
+++ b/src/update_node.rs
@@ -96,7 +96,7 @@ pub fn execute_update_node(opts: UpdateNodeOpts) -> Result<(), Error> {
             if node_network_address.domain != opts.domain {
                 let node_cluster = &node_network_address.cluster;
                 let host = if local_cluster.eq(node_cluster) {
-                    svc_name(&opts.chain_name, &opts.domain)
+                    svc_name(&opts.chain_name, &node_network_address.domain)
                 } else {
                     node_network_address.host.clone()
                 };
@@ -127,7 +127,7 @@ pub fn execute_update_node(opts: UpdateNodeOpts) -> Result<(), Error> {
                 let real_domain = format!("{}-{}", &opts.chain_name, &node_network_address.domain);
                 let node_cluster = &node_network_address.cluster;
                 let host = if local_cluster == node_cluster {
-                    svc_name(&opts.chain_name, &opts.domain)
+                    svc_name(&opts.chain_name, &node_network_address.domain)
                 } else {
                     node_network_address.host.clone()
                 };
@@ -183,6 +183,10 @@ pub fn execute_update_node(opts: UpdateNodeOpts) -> Result<(), Error> {
             node_config.grpc_ports.consensus_port,
         );
         consensus_config.write(&config_file_name);
+        // only for new node
+        if !is_old {
+            consensus_config.write_log4rs(&node_dir, opts.is_stdout, &node_config.log_level);
+        }
     } else if find_micro_service(&chain_config, CONSENSUS_BFT) {
         let consensus_config = ConsensusBft::new(
             node_config.grpc_ports.controller_port,

--- a/src/update_yaml.rs
+++ b/src/update_yaml.rs
@@ -1,0 +1,777 @@
+// Copyright Rivtower Technologies LLC.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::constant::{
+    CHAIN_CONFIG_FILE, CONSENSUS_BFT, CONSENSUS_RAFT, CONTROLLER, EXECUTOR_EVM, KMS_DB, KMS_ETH,
+    KMS_SM, NETWORK_P2P, NETWORK_TLS, NODE_CONFIG_FILE, STORAGE_ROCKSDB,
+};
+use crate::error::Error;
+use crate::util::{read_chain_config, read_file, read_node_config, svc_name, write_file};
+use clap::Parser;
+use k8s_openapi::api::apps::v1::StatefulSet;
+use k8s_openapi::api::apps::v1::StatefulSetSpec;
+use k8s_openapi::api::core::v1::ConfigMap;
+use k8s_openapi::api::core::v1::ConfigMapVolumeSource;
+use k8s_openapi::api::core::v1::Container;
+use k8s_openapi::api::core::v1::ContainerPort;
+use k8s_openapi::api::core::v1::PersistentVolumeClaim;
+use k8s_openapi::api::core::v1::PersistentVolumeClaimSpec;
+use k8s_openapi::api::core::v1::PodSpec;
+use k8s_openapi::api::core::v1::PodTemplateSpec;
+use k8s_openapi::api::core::v1::ResourceRequirements;
+use k8s_openapi::api::core::v1::Service;
+use k8s_openapi::api::core::v1::ServicePort;
+use k8s_openapi::api::core::v1::ServiceSpec;
+use k8s_openapi::api::core::v1::Volume;
+use k8s_openapi::api::core::v1::VolumeMount;
+use k8s_openapi::apimachinery::pkg::api::resource::Quantity;
+use k8s_openapi::apimachinery::pkg::apis::meta::v1::LabelSelector;
+use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+use k8s_openapi::apimachinery::pkg::util::intstr::IntOrString;
+use k8s_openapi::ByteString;
+use std::collections::BTreeMap;
+use std::fs;
+
+/// A subcommand for run
+#[derive(Parser, Debug, Clone)]
+pub struct UpdateYamlOpts {
+    /// set chain name
+    #[clap(long = "chain-name", default_value = "test-chain")]
+    pub(crate) chain_name: String,
+    /// set config file directory, default means current directory
+    #[clap(long = "config-dir", default_value = ".")]
+    pub(crate) config_dir: String,
+    /// set config file name
+    #[clap(long = "config-name", default_value = "config.toml")]
+    pub(crate) config_name: String,
+    /// domain of node
+    #[clap(long = "domain")]
+    pub(crate) domain: String,
+    /// image pull policy: IfNotPresent or Always
+    #[clap(long = "pull-policy", default_value = "IfNotPresent")]
+    pub(crate) pull_policy: String,
+    /// docker registry
+    #[clap(long = "docker-registry", default_value = "docker.io")]
+    pub(crate) docker_registry: String,
+    /// docker repo
+    #[clap(long = "docker-repo", default_value = "citacloud")]
+    pub(crate) docker_repo: String,
+    /// storage class
+    #[clap(long = "storage-class")]
+    pub(crate) storage_class: String,
+    /// storage capacity
+    #[clap(long = "storage-capacity", default_value = "10Gi")]
+    pub(crate) storage_capacity: String,
+}
+
+/// generate node config files by chain_config and node_config
+pub fn execute_update_yaml(opts: UpdateYamlOpts) -> Result<(), Error> {
+    let node_name = format!("{}-{}", &opts.chain_name, &opts.domain);
+    let node_dir = format!("{}/{}", &opts.config_dir, &node_name);
+
+    // load node_config
+    let file_name = format!("{}/{}", &node_dir, NODE_CONFIG_FILE);
+    let node_config = read_node_config(file_name).unwrap();
+
+    // load chain_config
+    let file_name = format!("{}/{}", &node_dir, CHAIN_CONFIG_FILE);
+    let chain_config = read_chain_config(&file_name).unwrap();
+
+    let config_file_name = format!("{}/{}", &node_dir, opts.config_name);
+
+    let yamls_path = format!("{}/yamls", &node_dir);
+    fs::create_dir_all(&yamls_path).unwrap();
+
+    // update yaml
+    // node port svc
+    // statefulset
+    // configmap about config.toml
+    // configmap about all log4rs.yaml
+    // configmap about account
+    {
+        let mut metadata = ObjectMeta {
+            name: Some(format!("{}-config", &node_name)),
+            ..Default::default()
+        };
+        let mut labels = BTreeMap::new();
+        labels.insert(
+            "app.kubernetes.io/chain-name".to_string(),
+            opts.chain_name.clone(),
+        );
+        labels.insert(
+            "app.kubernetes.io/chain-node".to_string(),
+            node_name.clone(),
+        );
+        metadata.labels = Some(labels);
+
+        let mut cm_config = ConfigMap {
+            metadata,
+            ..Default::default()
+        };
+        let mut data = BTreeMap::new();
+        data.insert(
+            "config.toml".to_string(),
+            read_file(&config_file_name).unwrap(),
+        );
+        cm_config.data = Some(data);
+
+        let yaml_file_name = format!("{}/{}-cm-config.yaml", &yamls_path, &node_name);
+        write_file(
+            serde_yaml::to_string(&cm_config).unwrap().as_bytes(),
+            &yaml_file_name,
+        );
+    }
+
+    {
+        let mut metadata = ObjectMeta {
+            name: Some(format!("{}-log", &node_name)),
+            ..Default::default()
+        };
+        let mut labels = BTreeMap::new();
+        labels.insert(
+            "app.kubernetes.io/chain-name".to_string(),
+            opts.chain_name.clone(),
+        );
+        labels.insert(
+            "app.kubernetes.io/chain-node".to_string(),
+            node_name.clone(),
+        );
+        metadata.labels = Some(labels);
+
+        let mut cm_log = ConfigMap {
+            metadata,
+            ..Default::default()
+        };
+        let mut data = BTreeMap::new();
+        data.insert(
+            "consensus-log4rs.yaml".to_string(),
+            read_file(&format!("{}/consensus-log4rs.yaml", &node_dir)).unwrap(),
+        );
+        data.insert(
+            "controller-log4rs.yaml".to_string(),
+            read_file(&format!("{}/controller-log4rs.yaml", &node_dir)).unwrap(),
+        );
+        data.insert(
+            "executor-log4rs.yaml".to_string(),
+            read_file(&format!("{}/executor-log4rs.yaml", &node_dir)).unwrap(),
+        );
+        data.insert(
+            "kms-log4rs.yaml".to_string(),
+            read_file(&format!("{}/kms-log4rs.yaml", &node_dir)).unwrap(),
+        );
+        data.insert(
+            "network-log4rs.yaml".to_string(),
+            read_file(&format!("{}/network-log4rs.yaml", &node_dir)).unwrap(),
+        );
+        data.insert(
+            "storage-log4rs.yaml".to_string(),
+            read_file(&format!("{}/storage-log4rs.yaml", &node_dir)).unwrap(),
+        );
+        cm_log.data = Some(data);
+
+        let yaml_file_name = format!("{}/{}-cm-log.yaml", &yamls_path, &node_name);
+        write_file(
+            serde_yaml::to_string(&cm_log).unwrap().as_bytes(),
+            &yaml_file_name,
+        );
+    }
+
+    {
+        let mut metadata = ObjectMeta {
+            name: Some(format!("{}-account", &node_name)),
+            ..Default::default()
+        };
+        let mut labels = BTreeMap::new();
+        labels.insert(
+            "app.kubernetes.io/chain-name".to_string(),
+            opts.chain_name.clone(),
+        );
+        labels.insert(
+            "app.kubernetes.io/chain-node".to_string(),
+            node_name.clone(),
+        );
+        metadata.labels = Some(labels);
+
+        let mut cm_account = ConfigMap {
+            metadata,
+            ..Default::default()
+        };
+        let mut data = BTreeMap::new();
+        data.insert("address".to_string(), node_config.account.clone());
+        data.insert("keyId".to_string(), format!("{}", node_config.key_id));
+        cm_account.data = Some(data);
+
+        let mut binary_data = BTreeMap::new();
+        binary_data.insert(
+            KMS_DB.to_string(),
+            ByteString(fs::read(&format!("{}/{}", &node_dir, KMS_DB)).unwrap()),
+        );
+        cm_account.binary_data = Some(binary_data);
+
+        let yaml_file_name = format!("{}/{}-cm-account.yaml", &yamls_path, &node_name);
+        write_file(
+            serde_yaml::to_string(&cm_account).unwrap().as_bytes(),
+            &yaml_file_name,
+        );
+    }
+
+    {
+        let mut metadata = ObjectMeta {
+            name: Some(node_name.clone()),
+            ..Default::default()
+        };
+        let mut labels = BTreeMap::new();
+        labels.insert(
+            "app.kubernetes.io/chain-name".to_string(),
+            opts.chain_name.clone(),
+        );
+        labels.insert(
+            "app.kubernetes.io/chain-node".to_string(),
+            node_name.clone(),
+        );
+        metadata.labels = Some(labels);
+
+        let mut statefulset = StatefulSet {
+            metadata,
+            ..Default::default()
+        };
+
+        let mut spec = StatefulSetSpec::default();
+
+        let mut selector = LabelSelector::default();
+        let mut match_labels = BTreeMap::new();
+        match_labels.insert(
+            "app.kubernetes.io/chain-name".to_string(),
+            opts.chain_name.clone(),
+        );
+        match_labels.insert(
+            "app.kubernetes.io/chain-node".to_string(),
+            node_name.clone(),
+        );
+        selector.match_labels = Some(match_labels);
+
+        spec.selector = selector;
+
+        spec.replicas = Some(1);
+
+        let mut volume_claim_templates = Vec::new();
+
+        let metadata = ObjectMeta {
+            name: Some("datadir".to_string()),
+            ..Default::default()
+        };
+        let mut pvc = PersistentVolumeClaim {
+            metadata,
+            ..Default::default()
+        };
+        let mut pvc_spec = PersistentVolumeClaimSpec {
+            access_modes: Some(vec!["ReadWriteOnce".to_string()]),
+            ..Default::default()
+        };
+        let mut resources = ResourceRequirements::default();
+        let mut requests = BTreeMap::new();
+        requests.insert(
+            "storage".to_string(),
+            Quantity(opts.storage_capacity.clone()),
+        );
+        resources.requests = Some(requests);
+        pvc_spec.resources = Some(resources);
+        pvc_spec.storage_class_name = Some(opts.storage_class.clone());
+        pvc.spec = Some(pvc_spec);
+        volume_claim_templates.push(pvc);
+        spec.volume_claim_templates = Some(volume_claim_templates);
+
+        let mut template = PodTemplateSpec::default();
+
+        let mut metadata = ObjectMeta::default();
+        let mut labels = BTreeMap::new();
+        labels.insert(
+            "app.kubernetes.io/chain-name".to_string(),
+            opts.chain_name.clone(),
+        );
+        labels.insert(
+            "app.kubernetes.io/chain-node".to_string(),
+            node_name.clone(),
+        );
+        metadata.labels = Some(labels);
+        template.metadata = Some(metadata);
+
+        let mut template_spec = PodSpec::default();
+        let mut containers = Vec::new();
+        // network
+        let mut network_container = Container {
+            name: "network".to_string(),
+            image_pull_policy: Some(opts.pull_policy.clone()),
+            ports: Some(vec![
+                ContainerPort {
+                    container_port: 40000,
+                    name: Some("network".to_string()),
+                    protocol: Some("TCP".to_string()),
+                    ..Default::default()
+                },
+                ContainerPort {
+                    container_port: 50000,
+                    name: Some("grpc".to_string()),
+                    protocol: Some("TCP".to_string()),
+                    ..Default::default()
+                },
+            ]),
+            volume_mounts: Some(vec![
+                VolumeMount {
+                    mount_path: "/data".to_string(),
+                    name: "datadir".to_string(),
+                    ..Default::default()
+                },
+                VolumeMount {
+                    mount_path: "/etc/cita-cloud/config".to_string(),
+                    name: "node-config".to_string(),
+                    ..Default::default()
+                },
+                VolumeMount {
+                    mount_path: "/etc/cita-cloud/log".to_string(),
+                    name: "node-log".to_string(),
+                    ..Default::default()
+                },
+            ]),
+            working_dir: Some("/data".to_string()),
+            ..Default::default()
+        };
+
+        for micro_service in &chain_config.micro_service_list {
+            if micro_service.image == NETWORK_TLS {
+                network_container.image = Some(format!(
+                    "{}/{}/{}:{}",
+                    &opts.docker_registry,
+                    &opts.docker_repo,
+                    &micro_service.image,
+                    &micro_service.tag
+                ));
+                network_container.command = Some(vec![
+                    "network".to_string(),
+                    "run".to_string(),
+                    "-c".to_string(),
+                    "/etc/cita-cloud/config/config.toml".to_string(),
+                    "--stdout".to_string(),
+                ]);
+            } else if micro_service.image == NETWORK_P2P {
+                network_container.image = Some(format!(
+                    "{}/{}/{}:{}",
+                    &opts.docker_registry,
+                    &opts.docker_repo,
+                    &micro_service.image,
+                    &micro_service.tag
+                ));
+                network_container.command = Some(vec![
+                    "network".to_string(),
+                    "run".to_string(),
+                    "-c".to_string(),
+                    "/etc/cita-cloud/config/config.toml".to_string(),
+                    "-l".to_string(),
+                    "/etc/cita-cloud/log/network-log4rs.yaml".to_string(),
+                ]);
+            }
+        }
+
+        containers.push(network_container);
+
+        // consensus
+        let mut consensus_container = Container {
+            name: "consensus".to_string(),
+            image_pull_policy: Some(opts.pull_policy.clone()),
+            ports: Some(vec![ContainerPort {
+                container_port: 50001,
+                name: Some("grpc".to_string()),
+                protocol: Some("TCP".to_string()),
+                ..Default::default()
+            }]),
+            volume_mounts: Some(vec![
+                VolumeMount {
+                    mount_path: "/data".to_string(),
+                    name: "datadir".to_string(),
+                    ..Default::default()
+                },
+                VolumeMount {
+                    mount_path: "/etc/cita-cloud/config".to_string(),
+                    name: "node-config".to_string(),
+                    ..Default::default()
+                },
+                VolumeMount {
+                    mount_path: "/etc/cita-cloud/log".to_string(),
+                    name: "node-log".to_string(),
+                    ..Default::default()
+                },
+            ]),
+            working_dir: Some("/data".to_string()),
+            ..Default::default()
+        };
+
+        for micro_service in &chain_config.micro_service_list {
+            if micro_service.image == CONSENSUS_RAFT {
+                consensus_container.image = Some(format!(
+                    "{}/{}/{}:{}",
+                    &opts.docker_registry,
+                    &opts.docker_repo,
+                    &micro_service.image,
+                    &micro_service.tag
+                ));
+                consensus_container.command = Some(vec![
+                    "consensus".to_string(),
+                    "run".to_string(),
+                    "-c".to_string(),
+                    "/etc/cita-cloud/config/config.toml".to_string(),
+                    "--stdout".to_string(),
+                ]);
+            } else if micro_service.image == CONSENSUS_BFT {
+                consensus_container.image = Some(format!(
+                    "{}/{}/{}:{}",
+                    &opts.docker_registry,
+                    &opts.docker_repo,
+                    &micro_service.image,
+                    &micro_service.tag
+                ));
+                consensus_container.command = Some(vec![
+                    "network".to_string(),
+                    "run".to_string(),
+                    "-c".to_string(),
+                    "/etc/cita-cloud/config/config.toml".to_string(),
+                    "-l".to_string(),
+                    "/etc/cita-cloud/log/consensus-log4rs.yaml".to_string(),
+                ]);
+            }
+        }
+
+        containers.push(consensus_container);
+
+        // executor
+        let mut executor_container = Container {
+            name: "executor".to_string(),
+            image_pull_policy: Some(opts.pull_policy.clone()),
+            ports: Some(vec![ContainerPort {
+                container_port: 50002,
+                name: Some("grpc".to_string()),
+                protocol: Some("TCP".to_string()),
+                ..Default::default()
+            }]),
+            volume_mounts: Some(vec![
+                VolumeMount {
+                    mount_path: "/data".to_string(),
+                    name: "datadir".to_string(),
+                    ..Default::default()
+                },
+                VolumeMount {
+                    mount_path: "/etc/cita-cloud/config".to_string(),
+                    name: "node-config".to_string(),
+                    ..Default::default()
+                },
+                VolumeMount {
+                    mount_path: "/etc/cita-cloud/log".to_string(),
+                    name: "node-log".to_string(),
+                    ..Default::default()
+                },
+            ]),
+            working_dir: Some("/data".to_string()),
+            ..Default::default()
+        };
+
+        for micro_service in &chain_config.micro_service_list {
+            if micro_service.image == EXECUTOR_EVM {
+                executor_container.image = Some(format!(
+                    "{}/{}/{}:{}",
+                    &opts.docker_registry,
+                    &opts.docker_repo,
+                    &micro_service.image,
+                    &micro_service.tag
+                ));
+                executor_container.command = Some(vec![
+                    "executor".to_string(),
+                    "run".to_string(),
+                    "-c".to_string(),
+                    "/etc/cita-cloud/config/config.toml".to_string(),
+                    "-l".to_string(),
+                    "/etc/cita-cloud/log/executor-log4rs.yaml".to_string(),
+                ]);
+            }
+        }
+
+        containers.push(executor_container);
+
+        // storage
+        let mut storage_container = Container {
+            name: "storage".to_string(),
+            image_pull_policy: Some(opts.pull_policy.clone()),
+            ports: Some(vec![ContainerPort {
+                container_port: 50003,
+                name: Some("grpc".to_string()),
+                protocol: Some("TCP".to_string()),
+                ..Default::default()
+            }]),
+            volume_mounts: Some(vec![
+                VolumeMount {
+                    mount_path: "/data".to_string(),
+                    name: "datadir".to_string(),
+                    ..Default::default()
+                },
+                VolumeMount {
+                    mount_path: "/etc/cita-cloud/config".to_string(),
+                    name: "node-config".to_string(),
+                    ..Default::default()
+                },
+                VolumeMount {
+                    mount_path: "/etc/cita-cloud/log".to_string(),
+                    name: "node-log".to_string(),
+                    ..Default::default()
+                },
+            ]),
+            working_dir: Some("/data".to_string()),
+            ..Default::default()
+        };
+
+        for micro_service in &chain_config.micro_service_list {
+            if micro_service.image == STORAGE_ROCKSDB {
+                storage_container.image = Some(format!(
+                    "{}/{}/{}:{}",
+                    &opts.docker_registry,
+                    &opts.docker_repo,
+                    &micro_service.image,
+                    &micro_service.tag
+                ));
+                storage_container.command = Some(vec![
+                    "storage".to_string(),
+                    "run".to_string(),
+                    "-c".to_string(),
+                    "/etc/cita-cloud/config/config.toml".to_string(),
+                    "-l".to_string(),
+                    "/etc/cita-cloud/log/storage-log4rs.yaml".to_string(),
+                ]);
+            }
+        }
+
+        containers.push(storage_container);
+
+        // controller
+        let mut controller_container = Container {
+            name: "controller".to_string(),
+            image_pull_policy: Some(opts.pull_policy.clone()),
+            ports: Some(vec![ContainerPort {
+                container_port: 50004,
+                name: Some("grpc".to_string()),
+                protocol: Some("TCP".to_string()),
+                ..Default::default()
+            }]),
+            volume_mounts: Some(vec![
+                VolumeMount {
+                    mount_path: "/data".to_string(),
+                    name: "datadir".to_string(),
+                    ..Default::default()
+                },
+                VolumeMount {
+                    mount_path: "/etc/cita-cloud/config".to_string(),
+                    name: "node-config".to_string(),
+                    ..Default::default()
+                },
+                VolumeMount {
+                    mount_path: "/etc/cita-cloud/log".to_string(),
+                    name: "node-log".to_string(),
+                    ..Default::default()
+                },
+            ]),
+            working_dir: Some("/data".to_string()),
+            ..Default::default()
+        };
+
+        for micro_service in &chain_config.micro_service_list {
+            if micro_service.image == CONTROLLER {
+                controller_container.image = Some(format!(
+                    "{}/{}/{}:{}",
+                    &opts.docker_registry,
+                    &opts.docker_repo,
+                    &micro_service.image,
+                    &micro_service.tag
+                ));
+                controller_container.command = Some(vec![
+                    "controller".to_string(),
+                    "run".to_string(),
+                    "-c".to_string(),
+                    "/etc/cita-cloud/config/config.toml".to_string(),
+                    "-l".to_string(),
+                    "/etc/cita-cloud/log/controller-log4rs.yaml".to_string(),
+                ]);
+            }
+        }
+
+        containers.push(controller_container);
+
+        // kms
+        let mut kms_container = Container {
+            name: "kms".to_string(),
+            image_pull_policy: Some(opts.pull_policy.clone()),
+            ports: Some(vec![ContainerPort {
+                container_port: 50005,
+                name: Some("grpc".to_string()),
+                protocol: Some("TCP".to_string()),
+                ..Default::default()
+            }]),
+            volume_mounts: Some(vec![
+                VolumeMount {
+                    mount_path: "/data".to_string(),
+                    name: "datadir".to_string(),
+                    ..Default::default()
+                },
+                VolumeMount {
+                    mount_path: "/etc/cita-cloud/config".to_string(),
+                    name: "node-config".to_string(),
+                    ..Default::default()
+                },
+                VolumeMount {
+                    mount_path: "/etc/cita-cloud/log".to_string(),
+                    name: "node-log".to_string(),
+                    ..Default::default()
+                },
+                VolumeMount {
+                    mount_path: "/mnt".to_string(),
+                    name: "node-account".to_string(),
+                    ..Default::default()
+                },
+            ]),
+            working_dir: Some("/data".to_string()),
+            ..Default::default()
+        };
+
+        for micro_service in &chain_config.micro_service_list {
+            if micro_service.image == KMS_ETH || micro_service.image == KMS_SM {
+                kms_container.image = Some(format!(
+                    "{}/{}/{}:{}",
+                    &opts.docker_registry,
+                    &opts.docker_repo,
+                    &micro_service.image,
+                    &micro_service.tag
+                ));
+                kms_container.command = Some(vec!["/bin/sh".to_string(),
+          "-c".to_string(),
+          "if [ ! -f \"/data/kms.db\" ]; then cp /mnt/kms.db /data;fi; kms run -c /etc/cita-cloud/config/config.toml -l /etc/cita-cloud/log/kms-log4rs.yaml".to_string(),
+          ]);
+            }
+        }
+
+        containers.push(kms_container);
+
+        template_spec.containers = containers;
+
+        template_spec.volumes = Some(vec![
+            Volume {
+                name: "node-account".to_string(),
+                config_map: Some(ConfigMapVolumeSource {
+                    name: Some(format!("{}-account", &node_name)),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            },
+            Volume {
+                name: "node-config".to_string(),
+                config_map: Some(ConfigMapVolumeSource {
+                    name: Some(format!("{}-config", &node_name)),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            },
+            Volume {
+                name: "node-log".to_string(),
+                config_map: Some(ConfigMapVolumeSource {
+                    name: Some(format!("{}-log", &node_name)),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            },
+        ]);
+
+        template.spec = Some(template_spec);
+
+        spec.template = template;
+        statefulset.spec = Some(spec);
+
+        let yaml_file_name = format!("{}/{}.yaml", &yamls_path, &node_name);
+        write_file(
+            serde_yaml::to_string(&statefulset).unwrap().as_bytes(),
+            &yaml_file_name,
+        );
+    }
+
+    {
+        let mut nodeport_svc = Service::default();
+
+        let mut metadata = ObjectMeta {
+            name: Some(svc_name(&opts.chain_name, &opts.domain)),
+            ..Default::default()
+        };
+        let mut labels = BTreeMap::new();
+        labels.insert(
+            "app.kubernetes.io/chain-name".to_string(),
+            opts.chain_name.clone(),
+        );
+        labels.insert(
+            "app.kubernetes.io/chain-node".to_string(),
+            node_name.clone(),
+        );
+        metadata.labels = Some(labels);
+
+        nodeport_svc.metadata = metadata;
+
+        let mut svc_spec = ServiceSpec {
+            type_: Some("NodePort".to_string()),
+            ..Default::default()
+        };
+
+        let mut match_labels = BTreeMap::new();
+        match_labels.insert("app.kubernetes.io/chain-name".to_string(), opts.chain_name);
+        match_labels.insert(
+            "app.kubernetes.io/chain-node".to_string(),
+            node_name.clone(),
+        );
+        svc_spec.selector = Some(match_labels);
+
+        svc_spec.ports = Some(vec![
+            ServicePort {
+                name: Some("network".to_string()),
+                port: 40000,
+                target_port: Some(IntOrString::Int(40000)),
+                protocol: Some("TCP".to_string()),
+                ..Default::default()
+            },
+            ServicePort {
+                name: Some("rpc".to_string()),
+                port: 50004,
+                target_port: Some(IntOrString::Int(50004)),
+                protocol: Some("TCP".to_string()),
+                ..Default::default()
+            },
+            ServicePort {
+                name: Some("call".to_string()),
+                port: 50002,
+                target_port: Some(IntOrString::Int(50002)),
+                protocol: Some("TCP".to_string()),
+                ..Default::default()
+            },
+        ]);
+
+        nodeport_svc.spec = Some(svc_spec);
+
+        let yaml_file_name = format!("{}/{}-svc.yaml", &yamls_path, &node_name);
+        write_file(
+            serde_yaml::to_string(&nodeport_svc).unwrap().as_bytes(),
+            &yaml_file_name,
+        );
+    }
+
+    Ok(())
+}

--- a/src/util.rs
+++ b/src/util.rs
@@ -22,7 +22,7 @@ use rcgen::{
 };
 use std::io::{Read, Write};
 use std::time::{SystemTime, UNIX_EPOCH};
-use std::{fs, path};
+use std::{fs, io, path};
 use toml::de::Error;
 use toml::Value;
 
@@ -180,4 +180,18 @@ pub fn check_address(s: &str) -> &str {
         panic!("wrong address, please check!")
     };
     addr
+}
+
+pub fn copy_dir_all(src: impl AsRef<path::Path>, dst: impl AsRef<path::Path>) -> io::Result<()> {
+    let _ = fs::create_dir_all(&dst);
+    for entry in fs::read_dir(src)? {
+        let entry = entry?;
+        let path = entry.path();
+        if path.is_dir() {
+            copy_dir_all(entry.path(), dst.as_ref().join(entry.file_name()))?;
+        } else {
+            fs::copy(entry.path(), dst.as_ref().join(entry.file_name()))?;
+        }
+    }
+    Ok(())
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -207,5 +207,5 @@ pub fn rand_string() -> String {
 }
 
 pub fn svc_name(chain_name: &str, domain: &str) -> String {
-    format!("svc-{}-{}", chain_name, domain)
+    format!("{}-{}-nodeport", chain_name, domain)
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -16,6 +16,8 @@ use crate::config::chain_config::ChainConfig;
 use crate::config::node_config::NodeConfig;
 use crate::constant::KMS_DB;
 use crate::traits::Kms;
+use rand::distributions::Alphanumeric;
+use rand::{thread_rng, Rng};
 use rcgen::{
     BasicConstraints, Certificate, CertificateParams, CertificateSigningRequest, IsCa, KeyPair,
     PKCS_ECDSA_P256_SHA256,
@@ -194,4 +196,16 @@ pub fn copy_dir_all(src: impl AsRef<path::Path>, dst: impl AsRef<path::Path>) ->
         }
     }
     Ok(())
+}
+
+pub fn rand_string() -> String {
+    thread_rng()
+        .sample_iter(&Alphanumeric)
+        .take(8)
+        .map(char::from)
+        .collect()
+}
+
+pub fn svc_name(chain_name: &str, domain: &str) -> String {
+    format!("svc-{}-{}", chain_name, domain)
 }


### PR DESCRIPTION
* split chain an node 原来chain和node会公用一些文件。现在把相关文件都复制一份，保证每个文件夹都是自满足的。便于将来将两者分别放到对外和对内的两个git仓库中。
* impl log_level 这个可能是原来漏掉了，node配置里的log-level没有生效。
* add stage 在chain config中增加stage字段，描述chain config生成过程进行到什么阶段。在子命令中增加对stage的判断，避免一些误操作。
* add cluster name and svc port  在append node的时候增加cluster name和svc port字段。init node的时候传入cluster name。如果cluster name 相同就会使用svc作为host，svc port作为port，否则还是用原来的host和port。用于兼容跨集群的场景。
* add import ca and cert 用于支持导入已有的证书，而不是用自签的证书。需要的pem格式的证书和key，这两条子命令只是简单的文件拷贝，不负责格式转换。
*  add update yaml 在update node生成配置文件的基础上，生成节点在k8s里部署所需的资源清单。  
* code clean and update readme 代码清理，更新文档